### PR TITLE
Remove newline rule from linter to acommodate windows & unix differences

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,7 +21,6 @@ module.exports = {
         ]
     },
     rules: {
-        "linebreak-style": ["error", "unix"],
         "arrow-spacing": [
             "error",
             {


### PR DESCRIPTION
Github pulls and converts LF `\n` to CRLF `\r\n` during development but converts CRLF back to LF when pushed to remote. Thus the `linebreak-style` rule showed issues for the CRLF line breaks when `npm run format` is run when in reality, it's auto fixed downstream.