### PR TITLE
Revert "npm run ci_format now prints the changes needed"

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "version": "0.1.0",
     "scripts": {
         "build": "react-scripts build",
-        "ci_format": "prettier-eslint $PWD/\"**/*.js\" $PWD/\"**/*.jsx\" && eslint \"**/*.js\" \"**/*.jsx\" && prettier-package-json --tab-width 4 ./package.json",
+        "ci_format": "prettier-eslint --list-different $PWD/\"**/*.js\" $PWD/\"**/*.jsx\" && eslint \"**/*.js\" \"**/*.jsx\" && prettier-package-json --list-different --tab-width 4 ./package.json",
         "eject": "react-scripts eject",
         "format": "prettier-eslint $PWD/\"**/*.js\" $PWD/\"**/*.jsx\" --write && eslint \"**/*.js\" \"**/*.jsx\" --fix && prettier-package-json --write --tab-width 4 ./package.json",
         "lint": "eslint \"**/*.js\" \"**/*.jsx\" --fix",


### PR DESCRIPTION
Reverts SESoc/public-website#42

turns out the linters will pass anything if i remove the --list-different tags, so adding those back in, unfortunately there isn't a way to display the changes that the linter wants while also making it fail if there are changes it wants