### PR TITLE
Fix text size on About page and formatting

### DIFF
--- a/src/components/styles/ProfilePhotoGroup.scss
+++ b/src/components/styles/ProfilePhotoGroup.scss
@@ -11,23 +11,16 @@
     width: 100%;
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (min-width: 462px) {
     .card {
-        font-size: calc(5px + .75vw);
+        font-size: calc(14px);
         line-height: calc(1.1em + 0.5vw);
     }
 }
 
-@media screen and (min-width: 768px) and (max-width: 991px) {
+@media screen and (max-width: 461px) {
     .card {
-        font-size: calc(10px + 1vw);
-        line-height: calc(1.1em + 0.5vw);
-    }
-}
-
-@media screen and (max-width: 768px) {
-    .card {
-        font-size: calc(10px + 0.5vw);
+        font-size: calc(9px + 0.25vw);
         line-height: calc(1.1em + 0.5vw);
     }
 }

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -91,7 +91,8 @@ const Content = props => {
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                SXSE Podcast S01E03 - How To Make The Most Out Of Your First Co-op!
+                SXSE Podcast S01E03 - How To Make The Most Out Of Your First
+                Co-op!
               </a>
             </p>
           </div>


### PR DESCRIPTION
- Set text for role descriptions on about page to a fixed size (14px) so *VP Communications* does not overflow on extra large screens
- Optimized text size for mobile view
- ran `npm run format`