### PR TITLE
Add podcasts 4 & 5, fix wrong month being displayed, sort posts desc

### DIFF
--- a/src/containers/Blog.jsx
+++ b/src/containers/Blog.jsx
@@ -12,7 +12,9 @@ import BlogPostsGroup from "../components/BlogPostsGroup.jsx";
 import {blogPosts} from "../content/BlogContent.js";
 import "./../App.scss";
 
-const getDate = (date, dateFn = date => date) => dateFn(Moment.unix(date));
+const getDate = (date, dateFn = date => date) => {
+  return dateFn(Moment.unix(date));
+};
 
 const formatPostsByDate = (blogPosts, dateFn, sortOrder) =>
   flow([
@@ -25,13 +27,16 @@ class Blog extends Component {
   renderBlogPosts(yearlyPosts) {
     const monthlyPosts = formatPostsByDate(
       yearlyPosts,
-      date => date.month(),
+      // 1. The Moment library has the audacity to return months (& dates) zero-indexed (0=Jan, 11=Dec)
+      // we don't need to worry about dates because we just sort with them (and never display them).
+      date => date.month() + 1,
       "desc",
     );
     return map(monthlyPosts, ([month, posts], index) => {
-      const orderedPosts = orderBy(posts, "date", "asc");
+      const orderedPosts = orderBy(posts, "date", "desc");
       return (
         <BlogPostsGroup
+          // 2. But when actually processing the month, treats it 1-indexed (1=Jan, 12=Dec)
           month={Moment(month).format("MMMM")}
           color={index % 2 === 0 ? "var(--color-eng)" : "var(--color-math)"}
           blogPosts={orderedPosts}

--- a/src/content/BlogContent.js
+++ b/src/content/BlogContent.js
@@ -58,7 +58,7 @@ const blogPosts = [
   },
   {
     type: BLOG_TYPES.PODCAST,
-    title: "SXSE S01E03 - How To Make The Most Out Of Your First Co-op!",
+    title: "SXSE S01E03 - How To Make The Most Out Of Your First Co-op",
     date: "1593561600",
     links: [
       {
@@ -75,6 +75,51 @@ const blogPosts = [
         type: "apple",
         link:
           "https://podcasts.apple.com/us/podcast/how-to-make-the-most-out-of-your-first-co-op/id1508757308?i=1000480893251",
+      },
+      podcastRSSLink,
+    ],
+  },
+  {
+    type: BLOG_TYPES.PODCAST,
+    title: "SXSE S01E04 - An SE Student's Guide to Extracurriculars",
+    date: "1596931200",
+    links: [
+      {
+        type: "spotify",
+        link: "https://open.spotify.com/episode/4gHp1pky25xFfYdl7SlnTV",
+      },
+      {
+        type: "anchor",
+        link:
+          "https://anchor.fm/sesoc/episodes/An-SE-Students-Guide-to-Extracurriculars-ehtc1v",
+      },
+      {
+        type: "apple",
+        link:
+          "https://podcasts.apple.com/us/podcast/an-se-students-guide-to-extracurriculars/id1508757308?i=1000487614833",
+      },
+      podcastRSSLink,
+    ],
+  },
+  {
+    type: BLOG_TYPES.PODCAST,
+    title:
+      "SXSE S01E05 - The Wild Adventure of First-Year Software Engineering",
+    date: "1598659200",
+    links: [
+      {
+        type: "spotify",
+        link: "https://open.spotify.com/episode/0uB0ULL9OC5mFSsy7oOGh5",
+      },
+      {
+        type: "anchor",
+        link:
+          "https://anchor.fm/sesoc/episodes/The-Wild-Adventure-of-First-Year-Software-Engineering-eir3ar",
+      },
+      {
+        type: "apple",
+        link:
+          "https://podcasts.apple.com/us/podcast/the-wild-adventure-of-first-year-software-engineering/id1508757308?i=1000489507047",
       },
       podcastRSSLink,
     ],


### PR DESCRIPTION
- Add podcast 4 & 5
- Originally the month being displayed was 1 month behind, this is because the Moment library returns months parsed from unix time as zero-indexed (i.e. Jan=0, Dec=11) but if we use .month(...), Moment returns it as 1 index (i.e. Jan=1, Dec=12).
https://stackoverflow.com/questions/20094812/getting-wrong-month-in-moment-js

- Sort posts within each month with newest post to the left (i.e. sort by descending) 