### PR TITLE
change the discord links to slack links on WiSE page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16597,9 +16597,9 @@
             }
         },
         "react": {
-            "version": "0.0.0-7f28234f8",
-            "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-7f28234f8.tgz",
-            "integrity": "sha512-WkSY1840EqOqW29kGaZ80QrGt6cMtsro6pnWCi2H48aMTiW3OKTOhKyqmMZW5TLA5bq1bsITcpv9hQies/OUFQ==",
+            "version": "17.0.0-rc.1",
+            "resolved": "https://registry.npmjs.org/react/-/react-17.0.0-rc.1.tgz",
+            "integrity": "sha512-sQ7X+k3zwf6cFQu9pD6FFJMwHwoKAV+EKLWRW4rD1ruyRiFkmC09cjtqFySLtaZbUdzYEc8iy4uOwisJNlXytg==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"
@@ -16899,13 +16899,13 @@
             }
         },
         "react-dom": {
-            "version": "0.0.0-7f28234f8",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-7f28234f8.tgz",
-            "integrity": "sha512-DyXQwHfBrIMSEwnRpHPVfD6R1XZtN7G4LyJ3VfveSaRrdtJriFvM3auhmUVofN4tsIAWWk0tzjiQ9dfDHLl1Yw==",
+            "version": "17.0.0-rc.1",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.0-rc.1.tgz",
+            "integrity": "sha512-MyWoPLxFUhSfIwFQa94Axm0h5IwzKJ3kzL7dxsW8iV36v881k+Lq7lVUN1+vDtBF0l51lkMe1mEITB3H5rinVg==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
-                "scheduler": "0.0.0-7f28234f8"
+                "scheduler": "0.20.0-rc.1"
             }
         },
         "react-error-overlay": {
@@ -18546,9 +18546,9 @@
             "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "scheduler": {
-            "version": "0.0.0-7f28234f8",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-7f28234f8.tgz",
-            "integrity": "sha512-ADxCc1+/qAf6iBqN0xH6mdQ/MNzoBpzEZ6YgDxkLJizx/Wf83zTJHVFvz5SqyetBr8T+UHh6+HygxHzHte+tTg==",
+            "version": "0.20.0-rc.1",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.0-rc.1.tgz",
+            "integrity": "sha512-agEhMxvDawRBHGbx6k+poNuzZ6XD+/XTl67R42sdJ/+yeioNDxaDiwxqTT9MjpvVBBdEzRzvnUvAccueb8Eb2w==",
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1"

--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -8,7 +8,7 @@ import EventCalendar from "../components/EventCalendar";
 import {getEvents, CALENDARS} from "../modules/gcal";
 import "./styles/Wise.scss";
 
-const DISCORD_LINK = "https://discord.gg/tbppDCc";
+const SLACK_LINK = "https://join.slack.com/t/uw-wise/signup"
 const MAILING_LIST_LINK = "https://lists.uwaterloo.ca/mailman/listinfo/women-in-se";
 const FACEBOOK_LINK = "https://forms.gle/piWhPZ85zyRVCNa77";
 const FEEDBACK_FORM_LINK = "https://forms.gle/rvzrQ7X4kStmKDYh9";
@@ -101,7 +101,7 @@ const FAQS = [
     question: "Where can I give my feedback about WiSE?",
     answer: (
       <p>
-        We love to hear feedback! You can give your feedback on our discord, or
+        We love to hear feedback! You can give your feedback on our slack, or
         for an anonymous option - fill out our{" "}
         <ExternalLink href={FEEDBACK_FORM_LINK}>feedback form</ExternalLink>.
       </p>
@@ -120,7 +120,7 @@ const FAQS = [
     question: "How can I get involved?",
     answer: (
       <p>
-        <ExternalLink href={DISCORD_LINK}>Join our discord!</ExternalLink> There
+        <ExternalLink href={SLACK_LINK}>Join our slack!</ExternalLink> There
         you can chat with other WiSE, make event suggestions and volunteer to
         help run events. You can also attend our planning meeting that is held
         at the beginning of each term.
@@ -164,11 +164,11 @@ const WhoWeAre = () => (
       <div className="mt-4">
         <Button
           variant="secondary"
-          className="discord-btn"
-          href={DISCORD_LINK}
+          className="slack-btn"
+          href={SLACK_LINK}
           target="_blank"
         >
-          Join Our Discord
+          Join Our Slack
         </Button>
       </div>
     </Col>
@@ -277,8 +277,8 @@ const GetInvolved = () => (
       actions={[
         {
           prompt: "Want to continue the conversation?",
-          buttonText: "Join Our Discord",
-          link: DISCORD_LINK,
+          buttonText: "Join Our Slack",
+          link: SLACK_LINK,
         },
         {
           prompt: "Interested in attending events?",

--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -8,7 +8,7 @@ import EventCalendar from "../components/EventCalendar";
 import {getEvents, CALENDARS} from "../modules/gcal";
 import "./styles/Wise.scss";
 
-const SLACK_LINK = "https://join.slack.com/t/uw-wise/signup"
+const SLACK_LINK = "https://join.slack.com/t/uw-wise/signup";
 const MAILING_LIST_LINK = "https://lists.uwaterloo.ca/mailman/listinfo/women-in-se";
 const FACEBOOK_LINK = "https://forms.gle/piWhPZ85zyRVCNa77";
 const FEEDBACK_FORM_LINK = "https://forms.gle/rvzrQ7X4kStmKDYh9";
@@ -120,10 +120,10 @@ const FAQS = [
     question: "How can I get involved?",
     answer: (
       <p>
-        <ExternalLink href={SLACK_LINK}>Join our slack!</ExternalLink> There
-        you can chat with other WiSE, make event suggestions and volunteer to
-        help run events. You can also attend our planning meeting that is held
-        at the beginning of each term.
+        <ExternalLink href={SLACK_LINK}>Join our slack!</ExternalLink> There you
+        can chat with other WiSE, make event suggestions and volunteer to help
+        run events. You can also attend our planning meeting that is held at the
+        beginning of each term.
       </p>
     ),
   },

--- a/src/containers/styles/Wise.scss
+++ b/src/containers/styles/Wise.scss
@@ -10,7 +10,7 @@
   height: auto;
 }
 
-.discord-btn {
+.slack-btn {
   background-color: $color-eng;
   border-width: 0px;
 }
@@ -26,7 +26,7 @@
   margin-bottom: 3px;
 }
 
-.cal-add-btn:hover, .discord-btn:hover {
+.cal-add-btn:hover, .slack-btn:hover {
   background-color: $color-eng-light;
 }
 


### PR DESCRIPTION
WiSE now uses Slack instead of Discord, WiSE Page should reflect this so as not to confuse people wanting to join from the SeSoc website.

The following are the 4 locations that previously had the discord wording and links, now they all say slack:

1. Bottom of intro paragraphs <img width="1059" alt="Screenshot 2020-09-17 at 8 15 59 PM" src="https://user-images.githubusercontent.com/22324472/93540980-4a10ad80-f923-11ea-9421-5a61ccb40451.png">

2. Where can I give feedback section <img width="1059" alt="Screenshot 2020-09-17 at 8 18 18 PM" src="https://user-images.githubusercontent.com/22324472/93540979-4a10ad80-f923-11ea-8315-49f84d86a528.png">

3. Where can I join section <img width="1059" alt="Screenshot 2020-09-17 at 8 16 38 PM" src="https://user-images.githubusercontent.com/22324472/93540981-4aa94400-f923-11ea-8049-ed6daa70baec.png">

4. Call to action buttons <img width="1059" alt="Screenshot 2020-09-17 at 8 15 49 PM" src="https://user-images.githubusercontent.com/22324472/93540969-44b36300-f923-11ea-931c-a1f3bfe6fe0f.png">
