### PR TITLE
Fix image padding and size on about page for mobile

### DIFF
--- a/src/components/ProfilePhotoGroup.jsx
+++ b/src/components/ProfilePhotoGroup.jsx
@@ -4,7 +4,7 @@ import {Card, Col, Row} from "react-bootstrap";
 import "./styles/ProfilePhotoGroup.scss";
 
 const Image = props => (
-  <Col xs={6} sm={6} md={6} lg={3} className="ml-0 pl-0">
+  <Col xs={6} sm={6} md={6} lg={3} className="ml-0 pl-0 pb-3">
     <Card className="ml-0 card" style={{width: "95%"}}>
       <Card.Header
         className="card-header"
@@ -18,7 +18,7 @@ const Image = props => (
           {props.person.position}
         </Card.Text>
       </Card.Header>
-      <Card.Img className="card-img" variant="bottom" src={props.person.src} />
+      <Card.Img variant="bottom" className="card-img" src={props.person.src} />
     </Card>
   </Col>
 );

--- a/src/components/styles/ProfilePhotoGroup.scss
+++ b/src/components/styles/ProfilePhotoGroup.scss
@@ -3,19 +3,15 @@
     margin-top: 30px;
 }
 
-.card-img {
-    padding: 0px;
-    margin: 0px;
-    border-radius: 0px 0px 5px 5px;
-    object-fit: cover;
-    width: 100%;
-}
-
 @media screen and (min-width: 462px) {
     .card {
         font-size: calc(14px);
         line-height: calc(1.1em + 0.5vw);
     }
+}
+
+.card-img {
+    max-height: 100% !important;
 }
 
 @media screen and (max-width: 461px) {


### PR DESCRIPTION
About us page use to have no bottom padding between images and images were very narrow in height. Fixed both of these issues:

<img width="473" alt="Screen Shot 2020-10-20 at 12 12 16 AM" src="https://user-images.githubusercontent.com/14525856/96539379-eb638a00-1268-11eb-9ed7-865b3aaf2c51.png">
