### PR TITLE
Start new Videos section on WiSE page

### DIFF
--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -323,7 +323,13 @@ const Videos = () => (
   <>
     <h2 className="pt-5 pb-2">Videos</h2>
     <h4>WiSE Upper Year Panel: Fall 2020</h4>
-    <iframe src="https://drive.google.com/file/d/1ouxt001mRjDq3p1StSJ57d7wXxxBpMdC/preview" width="1000" height="670"></iframe>
+    <iframe
+      title="WiSE Upper Year Panel: Fall 2020"
+      alt="WiSE Upper Year Panel: Fall 2020"
+      src="https://drive.google.com/file/d/1ouxt001mRjDq3p1StSJ57d7wXxxBpMdC/preview"
+      width="1000"
+      height="670"
+    />
   </>
 );
 

--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -319,6 +319,14 @@ const ImageSection = ({children}) => (
   </Row>
 );
 
+const Videos = () => (
+  <>
+    <h2 className="pt-5 pb-2">Videos</h2>
+    <h4>WiSE Upper Year Panel: Fall 2020</h4>
+    <iframe src="https://drive.google.com/file/d/1ouxt001mRjDq3p1StSJ57d7wXxxBpMdC/preview" width="1000" height="670"></iframe>
+  </>
+);
+
 ImageSection.propTypes = {children: PropTypes.node.isRequired};
 
 class Wise extends Component {
@@ -340,6 +348,7 @@ class Wise extends Component {
             <Name />
             <WhoWeAre />
             <Faqs faqs={FAQS} />
+            <Videos />
             <Events events={this.state.events} />
             <ImageSection>
               <Resources />


### PR DESCRIPTION
In the Fall 2020 term, WiSE recorded a panel with upper-year students. We wanted to add this video to the WiSE page, so I embedded the video in an iframe in it's own section on the page.