### PR TITLE
Fix calendar bug on home page and use async await for calendar API calls

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
     ],
   },
   rules: {
-    "no-console": "error",
+    "no-console": "warn",
     "no-param-reassign": "error",
     "react/jsx-key": ["off"],
   },

--- a/.htaccess
+++ b/.htaccess
@@ -1,6 +1,0 @@
-#!/bin/bash
-git pull
-npm install
-npm run build
-cp -r build/* ../www
-cp .htaccess ../www

--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,6 @@
+#!/bin/bash
+git pull
+npm install
+npm run build
+cp -r build/* ../www
+cp .htaccess ../www

--- a/src/containers/Events.jsx
+++ b/src/containers/Events.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { useEffect, useState } from 'react'
 import EventList from 'components/EventList'
 import EventCalendar from 'components/EventCalendar'
 import Footer from 'components/Footer'
@@ -7,53 +7,45 @@ import { getEvents, filterUpcomingEvents, CALENDARS } from 'modules/gcal'
 import 'App.scss'
 import 'containers/styles/Events.scss'
 
-class Events extends Component {
-  constructor() {
-    super()
-    this.state = {
-      events: [],
+const Events = () => {
+  const [events, setEvents] = useState([])
+
+  useEffect(() => {
+    async function getAllEvents() {
+      setEvents(await getEvents(CALENDARS.SESOC))
     }
-  }
+    getAllEvents()
+  }, [])
 
-  componentDidMount() {
-    getEvents(CALENDARS.SESOC, (events) => {
-      this.setState({ events })
-    })
-  }
-
-  render() {
-    return (
-      <div className="footer-to-bottom">
-        <body>
-          <Container className="mt-5 mb-5 flex-wrapper">
-            <Row>
-              <Col lg={5}>
-                <EventList
-                  upcomingEvents={filterUpcomingEvents(this.state.events)}
-                />
-              </Col>
-              <Col lg={7} className="mt-5 mt-sm-0">
-                <div className="cal">
-                  <EventCalendar events={this.state.events} />
-                </div>
-                <div className="mt-3">
-                  <Button
-                    variant="secondary"
-                    className="cal-add-btn"
-                    href="https://calendar.google.com/calendar?cid=bGI2dHRiMWtzMzdxbDVyOGlzdWFzZ2NkbzhAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
-                    target="_blank"
-                  >
-                    + Google Calendar
-                  </Button>
-                </div>
-              </Col>
-            </Row>
-          </Container>
-        </body>
-        <Footer color={'purple'} />
-      </div>
-    )
-  }
+  return (
+    <div className="footer-to-bottom">
+      <body>
+        <Container className="mt-5 mb-5 flex-wrapper">
+          <Row>
+            <Col lg={5}>
+              <EventList upcomingEvents={filterUpcomingEvents(events)} />
+            </Col>
+            <Col lg={7} className="mt-5 mt-sm-0">
+              <div className="cal">
+                <EventCalendar events={events} />
+              </div>
+              <div className="mt-3">
+                <Button
+                  variant="secondary"
+                  className="cal-add-btn"
+                  href="https://calendar.google.com/calendar?cid=bGI2dHRiMWtzMzdxbDVyOGlzdWFzZ2NkbzhAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ"
+                  target="_blank"
+                >
+                  + Google Calendar
+                </Button>
+              </div>
+            </Col>
+          </Row>
+        </Container>
+      </body>
+      <Footer color={'purple'} />
+    </div>
+  )
 }
 
 export default Events

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -1,10 +1,10 @@
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Container, Jumbotron, Row, Col } from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import url from 'url'
 import PropTypes from 'prop-types'
 import Footer from '../components/Footer'
-import { getEvents, filterUpcomingEvents } from '../modules/gcal'
+import { getEvents, CALENDARS, filterUpcomingEvents } from '../modules/gcal'
 import 'containers/styles/Home.scss'
 
 const heroImage = url.resolve(process.env.PUBLIC_URL, '/illustrations/hero.png')
@@ -111,31 +111,25 @@ Content.propTypes = {
   events: PropTypes.arrayOf(PropTypes.object).isRequired,
 }
 
-class Home extends Component {
-  constructor() {
-    super()
-    this.state = {
-      events: [],
+const Home = () => {
+  const [events, setEvents] = useState([])
+
+  useEffect(() => {
+    async function getAllEvents() {
+      setEvents(await getEvents(CALENDARS.SESOC))
     }
-  }
+    getAllEvents()
+  }, [])
 
-  componentDidMount() {
-    getEvents((events) => {
-      this.setState({ events })
-    })
-  }
-
-  render() {
-    return (
-      <div className="footer-to-bottom">
-        <body>
-          <Hero />
-          <Content events={filterUpcomingEvents(this.state.events)} />
-        </body>
-        <Footer color={'purple'} />
-      </div>
-    )
-  }
+  return (
+    <div className="footer-to-bottom">
+      <body>
+        <Hero />
+        <Content events={filterUpcomingEvents(events)} />
+      </body>
+      <Footer color={'purple'} />
+    </div>
+  )
 }
 
 export default Home

--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -1,4 +1,4 @@
-import React, { Component, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Container, Row, Col, Button, Accordion, Card } from 'react-bootstrap'
 import url from 'url'
 import PropTypes from 'prop-types'
@@ -342,37 +342,34 @@ const Videos = () => (
 
 ImageSection.propTypes = { children: PropTypes.node.isRequired }
 
-class Wise extends Component {
-  state = {
-    events: [],
-  }
+const Wise = () => {
+  const [events, setEvents] = useState([])
 
-  componentDidMount() {
-    getEvents(CALENDARS.WISE, (events) => {
-      this.setState({ events })
-    })
-  }
+  useEffect(() => {
+    async function getAllEvents() {
+      setEvents(await getEvents(CALENDARS.WISE))
+    }
+    getAllEvents()
+  }, [])
 
-  render() {
-    return (
-      <div className="footer-to-bottom">
-        <body>
-          <Container className="my-5 pb-4 flex-wrapper">
-            <Name />
-            <WhoWeAre />
-            <Faqs faqs={FAQS} />
-            <Videos />
-            <Events events={this.state.events} />
-            <ImageSection>
-              <Resources />
-              <GetInvolved />
-            </ImageSection>
-          </Container>
-        </body>
-        <Footer color={'pink'} />
-      </div>
-    )
-  }
+  return (
+    <div className="footer-to-bottom">
+      <body>
+        <Container className="my-5 pb-4 flex-wrapper">
+          <Name />
+          <WhoWeAre />
+          <Faqs faqs={FAQS} />
+          <Videos />
+          <Events events={events} />
+          <ImageSection>
+            <Resources />
+            <GetInvolved />
+          </ImageSection>
+        </Container>
+      </body>
+      <Footer color={'pink'} />
+    </div>
+  )
 }
 
 export default Wise

--- a/src/containers/Wise.jsx
+++ b/src/containers/Wise.jsx
@@ -231,7 +231,7 @@ Faqs.propTypes = {
   ).isRequired,
 }
 
-const Events = ({ events }) => (
+const WiseEvents = ({ events }) => (
   <div className="pb-5" id="wise-events">
     <h2 className="pt-5 pb-2">Events</h2>
     <div className="cal">
@@ -250,7 +250,7 @@ const Events = ({ events }) => (
   </div>
 )
 
-Events.propTypes = {
+WiseEvents.propTypes = {
   events: PropTypes.arrayOf(PropTypes.object).isRequired,
 }
 
@@ -360,7 +360,7 @@ const Wise = () => {
           <WhoWeAre />
           <Faqs faqs={FAQS} />
           <Videos />
-          <Events events={events} />
+          <WiseEvents events={events} />
           <ImageSection>
             <Resources />
             <GetInvolved />

--- a/src/modules/gcal.js
+++ b/src/modules/gcal.js
@@ -19,8 +19,8 @@ export async function getEvents(calendarType) {
   const { CALENDAR_ID, API_KEY } = calendarType
   const url = buildUrl(CALENDAR_ID, API_KEY)
 
-  const response = await Axios.get(url)
   const events = []
+  const response = await Axios.get(url)
   response.data.items.forEach((event) => {
     events.push({
       start: event.start.date || event.start.dateTime,
@@ -38,6 +38,7 @@ export async function getEvents(calendarType) {
       d2 = new Date(e2.start)
     return d1 - d2
   })
+
   return events
 }
 

--- a/src/modules/gcal.js
+++ b/src/modules/gcal.js
@@ -15,38 +15,30 @@ export const CALENDARS = {
 const buildUrl = (CALENDAR_ID, API_KEY) =>
   `https://www.googleapis.com/calendar/v3/calendars/${CALENDAR_ID}/events?key=${API_KEY}`
 
-export function getEvents(calendarType, callback) {
+export async function getEvents(calendarType) {
   const { CALENDAR_ID, API_KEY } = calendarType
   const url = buildUrl(CALENDAR_ID, API_KEY)
 
-  Axios.get(url).then(
-    (response) => {
-      const events = []
-      response.data.items.forEach((event) => {
-        events.push({
-          start: event.start.date || event.start.dateTime,
-          end: event.end.date || event.end.dateTime,
-          dateLabel: Moment(event.start.date || event.start.dateTime).format(
-            'MMMM Do, YYYY',
-          ),
-          title: event.summary,
-          description: event.description,
-          link: event.htmlLink,
-        })
-      })
-      callback(
-        events.sort((e1, e2) => {
-          var d1 = new Date(e1.start),
-            d2 = new Date(e2.start)
-          return d1 - d2
-        }),
-      )
-    },
-    (error) => {
-      // eslint-disable-next-line no-console
-      console.log(error)
-    },
-  )
+  const response = await Axios.get(url)
+  const events = []
+  response.data.items.forEach((event) => {
+    events.push({
+      start: event.start.date || event.start.dateTime,
+      end: event.end.date || event.end.dateTime,
+      dateLabel: Moment(event.start.date || event.start.dateTime).format(
+        'MMMM Do, YYYY',
+      ),
+      title: event.summary,
+      description: event.description,
+      link: event.htmlLink,
+    })
+  })
+  events.sort((e1, e2) => {
+    var d1 = new Date(e1.start),
+      d2 = new Date(e2.start)
+    return d1 - d2
+  })
+  return events
 }
 
 export function filterUpcomingEvents(events) {


### PR DESCRIPTION
The home page use to not show upcoming events because the function call was missing the `calendarType` param. This has been fixed.

Along the way, I've refactored the code a bit to use async/await as well as functional components for Home, Events & Wise pages.

No visual changes were made.